### PR TITLE
Fix three export-blocking bugs found while mirroring Framer/Webflow templates

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -8,6 +8,7 @@ export const CFG: Config = {
   concurrency: 12,
   retries: 3,
   dlTimeout: 30000,
+  antiBotMinContentChars: 500,
   sharedStripDomains: [
     'sentry.io', 'www.googletagmanager.com', 'connect.facebook.net',
     'stats.g.doubleclick.net',

--- a/src/exporter/anti-bot.ts
+++ b/src/exporter/anti-bot.ts
@@ -1,4 +1,5 @@
 import type { Page } from 'puppeteer';
+import { CFG } from '../config/index.js';
 import { ui } from '../cli/theme.js';
 
 export type AntiBotType = 'cloudflare' | 'captcha' | 'waf';
@@ -57,9 +58,8 @@ export async function detectAntiBotPage(page: Page): Promise<AntiBotType | null>
       return 'cloudflare';
     }
 
-    const flagged: string = await page.evaluate(() => {
+    const flagged: string = await page.evaluate((minContentChars: number) => {
       const body = document.body ? document.body.innerText || '' : '';
-      const outer = document.documentElement.outerHTML || '';
 
       // A challenge page has no content — it is a waiting screen. If the real
       // page is already here, nothing below indicates a block: those are just
@@ -68,8 +68,9 @@ export async function detectAntiBotPage(page: Page): Promise<AntiBotType | null>
       // Without this guard, any site embedding Cloudflare Turnstile or
       // reCAPTCHA in a contact form is reported as "protected by a browser
       // challenge" and the export aborts, even though the page rendered fully.
-      const HAS_REAL_CONTENT = body.trim().length >= 500;
-      if (HAS_REAL_CONTENT) return '';
+      if (body.trim().length >= minContentChars) return '';
+
+      const outer = document.documentElement.outerHTML || '';
 
       if (document.querySelector('iframe[src*="challenges.cloudflare.com"]')) return 'cloudflare';
       if (
@@ -83,7 +84,7 @@ export async function detectAntiBotPage(page: Page): Promise<AntiBotType | null>
         return 'cloudflare';
       }
       return '';
-    });
+    }, CFG.antiBotMinContentChars);
 
     return (flagged as AntiBotType) || null;
   } catch {

--- a/src/exporter/anti-bot.ts
+++ b/src/exporter/anti-bot.ts
@@ -58,6 +58,19 @@ export async function detectAntiBotPage(page: Page): Promise<AntiBotType | null>
     }
 
     const flagged: string = await page.evaluate(() => {
+      const body = document.body ? document.body.innerText || '' : '';
+      const outer = document.documentElement.outerHTML || '';
+
+      // A challenge page has no content — it is a waiting screen. If the real
+      // page is already here, nothing below indicates a block: those are just
+      // embedded widgets.
+      //
+      // Without this guard, any site embedding Cloudflare Turnstile or
+      // reCAPTCHA in a contact form is reported as "protected by a browser
+      // challenge" and the export aborts, even though the page rendered fully.
+      const HAS_REAL_CONTENT = body.trim().length >= 500;
+      if (HAS_REAL_CONTENT) return '';
+
       if (document.querySelector('iframe[src*="challenges.cloudflare.com"]')) return 'cloudflare';
       if (
         document.querySelector(
@@ -66,8 +79,6 @@ export async function detectAntiBotPage(page: Page): Promise<AntiBotType | null>
       ) {
         return 'captcha';
       }
-      const body = document.body ? document.body.innerText || '' : '';
-      const outer = document.documentElement.outerHTML || '';
       if (body.trim().length < 120 && /cf-chl|cloudflare|cf-browser-verification/i.test(outer)) {
         return 'cloudflare';
       }

--- a/src/exporter/capture.ts
+++ b/src/exporter/capture.ts
@@ -62,11 +62,15 @@ export async function launchAndCapture(exporter: ExporterContext): Promise<void>
 
   exporter.cooking?.update('Navigating to site...');
   info('Navigating to ' + exporter.siteUrl);
+  // Sites with several streaming <video> elements never reach networkidle2 (it
+  // requires <=2 in-flight connections), so navigation used to hard-fail with a
+  // timeout. The settle steps below — hydration wait, scroll, and an explicit
+  // waitForNetworkIdle guarded by try/catch — already handle quiescence.
   await exporter.page.goto(exporter.siteUrl, {
-    waitUntil: 'networkidle2',
+    waitUntil: 'domcontentloaded',
     timeout: CFG.timeout,
   });
-  success('Page loaded (networkidle2)');
+  success('Page loaded (domcontentloaded)');
   log('Intercepted ' + intercepted + ' resources, blocked ' + blocked + ' tracking requests');
 
   log('Checking DOM-based platform detection...');

--- a/src/platforms/webflow.ts
+++ b/src/platforms/webflow.ts
@@ -33,10 +33,14 @@ export const webflow: PlatformHandler = {
     /<style>[^<]*\.w-webflow-badge[^<]*<\/style>/g,
     /Powered by <a[^>]*href="[^"]*webflow\.com"[^>]*>[^<]*<\/a>/g,
     /<!-- This site was created in Webflow\.[^>]*-->/g,
-    /<html([^>]*) data-wf-domain="[^"]*"/g,
-    /<html([^>]*) data-wf-page="[^"]*"/g,
-    /<html([^>]*) data-wf-site="[^"]*"/g,
-    /<html([^>]*) data-wf-status="[^"]*"/g,
+    // NOTE: stripPatterns is applied as replace(pattern, '') — capture groups
+    // are never reinserted. Any pattern containing "<html" therefore deletes
+    // the whole opening tag, not just the attribute. Match the attribute only.
+    /\sdata-wf-domain="[^"]*"/g,
+    /\sdata-wf-status="[^"]*"/g,
+    // data-wf-page and data-wf-site are deliberately NOT stripped: IX2 reads
+    // them off the <html> element to resolve which interactions to run.
+    // Removing them silently kills every page-load animation.
     /<meta[^>]*content="Webflow"[^>]*>/g,
   ],
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,12 @@ export interface Config {
   concurrency: number;
   retries: number;
   dlTimeout: number;
+  /**
+   * Minimum characters of rendered body text for a page to count as "real
+   * content" rather than a challenge/waiting screen. Above it, embedded
+   * Turnstile/reCAPTCHA widgets are not treated as anti-bot blocks.
+   */
+  antiBotMinContentChars: number;
   sharedStripDomains: string[];
 }
 


### PR DESCRIPTION
Three independent bugs found while mirroring a batch of Framer and Webflow templates with `framer-export`. Each was traced to a root cause and verified with a before/after measurement. One commit per fix, all in English, no unrelated changes (`package-lock.json` deliberately untouched).

## 1. `stripPatterns` deletes the `<html>` tag on Webflow exports

`output.ts` applies patterns as `html.replace(pattern, '')`, so capture groups are never reinserted. Four Webflow patterns began with `<html([^>]*)`, so the opening tag was deleted along with the attribute:

```html
<!DOCTYPE html><!-- ... --> data-wf-page="694ba..." data-wf-site="694ba...">
```

The browser silently synthesises a replacement `<html>`, so the export *looks* almost right. But Webflow IX2 reads `data-wf-page` off the `<html>` element to resolve which interactions belong to the page. With the element gone, **every page-load interaction stops firing** while scroll-triggered ones keep working — a failure that is easy to miss without a baseline.

Measured on `tokko.webflow.io`: **45** elements stuck at `opacity: 0` against **23** on the live site — hero heading, pills, buttons and images, all page-load driven. After the fix: **23**, matching exactly.

Fix: match the attribute only, never the tag prefix. Also stops stripping `data-wf-page` / `data-wf-site` — those are functional IDs IX2 depends on, not vendor branding. `data-wf-domain` and `data-wf-status` are still removed.

## 2. Embedded Turnstile/reCAPTCHA reported as a browser challenge

`detectAntiBotPage` treated the presence of `iframe[src*="challenges.cloudflare.com"]` as proof of a challenge. Sites embedding Cloudflare Turnstile in a **contact form** inject exactly that iframe once `api.js` runs, so a fully rendered page aborted the export with `EXPORT BLOCKED — protected by Cloudflare`.

Measured on `blaxi.webflow.io` — title `Blaxi - Webflow HTML website template`, **4646** characters of body text, **120** images — and the detector still returned `'cloudflare'`. The suggested remedies (retry later, export from another IP) can't help, since nothing was ever blocked.

Fix: a challenge page has no content, it's a waiting screen. If the body carries ≥500 characters of real text, the widget checks are skipped. The existing low-content heuristics are untouched, so genuine challenges are still caught.

## 3. `networkidle2` times out on video-heavy sites

`networkidle2` requires ≤2 in-flight connections; a page with several streaming `<video>` elements never reaches it. `page.goto()` burned the full 90s timeout and the export failed outright.

Measured on `shinta.framer.media` (6 videos): `Navigation timeout of 90000 ms exceeded`, no files written — although the page renders fine in headless Chromium.

Fix: navigate with `domcontentloaded`. The steps right after already handle quiescence — hydration wait, full-page scroll, and an explicit `waitForNetworkIdle` wrapped in `try/catch`. Waiting for network idle twice only added a failure mode. Also corrects the success log, which still printed `networkidle2`.

## Verification

`tsc --noEmit` clean. Each site was measured live, then cloned, then measured again and compared against its own baseline (page height, count of `opacity: 0` elements, broken images, failed requests, requests still reaching the vendor CDN).

| Site | Before | After |
| --- | --- | --- |
| `tokko.webflow.io` | 45 hidden, 3 failed requests | 23 hidden (matches live), 0 failed |
| `blaxi.webflow.io` | export aborted | 9 hidden (matches live), 0 failed, 120/120 images |
| `shinta.framer.media` | export aborted | height and hidden count both match live |

Six other templates (`impacta`, `revento`, `ugency`, `scrolla`, `storyfluence`, `blooms`) were re-run after the changes with no regressions.

## One more issue, not fixed here

`capture.ts` stores `res.buffer()` for every OK response, including **`206 Partial Content`**. Video is always range-requested, so the saved `.mp4` is a truncated file that *exists on disk* and passes any presence check — only `ffprobe` catches it (`moov atom not found`). Across the templates above this corrupted **17 videos**, some rendering as blank rectangles.

I worked around it downstream (re-fetch the full file and validate with `ffprobe`) rather than patch it here, since a proper fix needs a re-download path inside the exporter and I didn't want to guess at the intended design. Happy to open a follow-up PR if you'd like it handled upstream — just let me know which shape you'd prefer.

Thanks for the tool — it was the only one of seven I benchmarked that preserved Framer's appear-animations end to end.

## Summary by Sourcery

Fix export-blocking issues affecting Webflow and Framer sites by improving anti-bot detection, preserving functional Webflow attributes, and making navigation robust on video-heavy pages.

Bug Fixes:
- Prevent embedded Cloudflare Turnstile and reCAPTCHA widgets on fully rendered pages from being misclassified as browser challenges that abort exports.
- Avoid stripping the opening <html> tag and critical data-wf-page/site attributes from Webflow exports when removing branding-related attributes.
- Eliminate navigation timeouts on video-heavy sites by using DOM content load as the primary page-load signal instead of network idle.

Enhancements:
- Clarify success logging to reflect the updated navigation strategy in the capture pipeline.