### PR TITLE
fix: make --subpages and Framer mirrors match the source site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,10 @@ coverage/
 *.map
 tmp/
 
+.visor/
+
 # generated site exports (never commit)
+/out/
 /cooksite-export/
 /framer-*/
 /webflow-*/

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Usage:
 Options:
   --setup            Launch interactive setup wizard
   --platform <name>  Force platform: framer | webflow | wix
+  --subpages         Crawl and export sub-pages
+  --dpr <number>     Capture device pixel ratio (default: 1)
   --legacy-mode      Use y/n text input instead of arrow selection
   --help, -h         Show help message
 ```

--- a/docs/superpowers/specs/2026-05-10-v5-multi-platform-design.md
+++ b/docs/superpowers/specs/2026-05-10-v5-multi-platform-design.md
@@ -88,7 +88,9 @@ export interface PlatformHandler {
 
   // assets
   mapAssetDir(host: string, pathname: string, ext: string): string | null;
-  rewriteUrlPatterns?: Array<{ from: RegExp; to: string }>;   // NEW
+  rewritePatterns?: Array<{ from: RegExp; to: string }>;      // NEW
+  /** @deprecated Use rewritePatterns. */
+  rewriteUrlPatterns?: Array<{ from: RegExp; to: string }>;
 
   // hooks
   preCapture?(page: Page): Promise<void>;                         // NEW

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "framer-export",
-  "version": "4.4.1",
+  "version": "5.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "framer-export",
-      "version": "4.4.1",
+      "version": "5.0.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -16,8 +16,9 @@
         "readline-promise": "^1.0.5"
       },
       "bin": {
-        "fexport": "dist/cli/index.js",
-        "framer-export": "dist/cli/index.js"
+        "fexport": "bin/fexport.js",
+        "framer-export": "bin/framer-export.js",
+        "framerexport": "bin/framerexport.js"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "start": "tsx src/cli/index.ts",
     "dev": "tsx src/cli/index.ts",
     "build": "tsup",
+    "test": "node --import tsx --test tests/unit/*.test.ts",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"src/**/*.ts\"",
     "prepublishOnly": "npm run build",

--- a/src/assets/asset-map.ts
+++ b/src/assets/asset-map.ts
@@ -7,6 +7,23 @@ interface AssetEntry {
   localPath: string;
 }
 
+/**
+ * Replace every occurrence of `url`, except where it is only the prefix of a
+ * deeper path: `https://framer.com/edit` also matches inside
+ * `https://framer.com/edit/init.mjs`, and rewriting that one would point a live
+ * module at a mirrored file that never had such a child.
+ */
+function replaceUrl(text: string, url: string, rel: string): string {
+  const parts: string[] = text.split(url);
+  if (parts.length === 1) return text;
+
+  let out: string = parts[0];
+  for (let i = 1; i < parts.length; i++) {
+    out += (parts[i].startsWith('/') ? url : rel) + parts[i];
+  }
+  return out;
+}
+
 export class AssetMap {
   entries: Map<string, AssetEntry> = new Map();
   buffers: Map<string, Buffer> = new Map();
@@ -69,9 +86,9 @@ export class AssetMap {
       // A same-directory path must stay explicitly relative, or JS dynamic
       // imports treat it as a bare module specifier and fail to resolve.
       if (fromDir && !rel.startsWith('.')) rel = './' + rel;
-      out = out.split(url).join(rel);
+      out = replaceUrl(out, url, rel);
       if (url.includes('&')) {
-        out = out.split(url.replace(/&/g, '&amp;')).join(rel);
+        out = replaceUrl(out, url.replace(/&/g, '&amp;'), rel);
       }
     }
     return out;

--- a/src/assets/asset-map.ts
+++ b/src/assets/asset-map.ts
@@ -13,7 +13,7 @@ interface AssetEntry {
  * `https://framer.com/edit/init.mjs`, and rewriting that one would point a live
  * module at a mirrored file that never had such a child.
  */
-function replaceUrl(text: string, url: string, rel: string): string {
+export function replaceUrl(text: string, url: string, rel: string): string {
   const parts: string[] = text.split(url);
   if (parts.length === 1) return text;
 

--- a/src/assets/asset-map.ts
+++ b/src/assets/asset-map.ts
@@ -65,7 +65,10 @@ export class AssetMap {
     const sorted = [...this.entries.entries()].sort((a, b) => b[0].length - a[0].length);
     let out: string = text;
     for (const [url, { localPath }] of sorted) {
-      const rel: string = fromDir ? path.posix.relative(fromDir, localPath) : localPath;
+      let rel: string = fromDir ? path.posix.relative(fromDir, localPath) : localPath;
+      // A same-directory path must stay explicitly relative, or JS dynamic
+      // imports treat it as a bare module specifier and fail to resolve.
+      if (fromDir && !rel.startsWith('.')) rel = './' + rel;
       out = out.split(url).join(rel);
       if (url.includes('&')) {
         out = out.split(url.replace(/&/g, '&amp;')).join(rel);

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -20,6 +20,7 @@ export function showHelp(): void {
     ['--setup', 'Launch the interactive setup assistant'],
     ['--platform <p>', 'Force platform by id (e.g. framer, shopify, notion)'],
     ['--subpages', 'Crawl and export sub-pages'],
+    ['--dpr <number>', 'Capture device pixel ratio (default: 1)'],
     ['--legacy-mode', 'Use text input instead of arrow selection'],
     ['--help, -h', 'Show this help message'],
   ];

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -130,7 +130,20 @@ async function main(): Promise<void> {
   }
 
   const platformOverride = extractFlag(args, '--platform') as PlatformType | null;
+  const hasDprFlag = args.includes('--dpr');
+  const dprValue = extractFlag(args, '--dpr');
   const includeSubpages: boolean = hasFlag(args, '--subpages');
+
+  const deviceScaleFactor = dprValue === null ? 1 : Number(dprValue);
+  if (
+    (hasDprFlag && dprValue === null) ||
+    !Number.isFinite(deviceScaleFactor) ||
+    deviceScaleFactor <= 0
+  ) {
+    console.log(`  ${ui.error('✗')} ${ui.error.bold('Invalid DPR:')} ${ui.text(dprValue || '')}`);
+    console.log(`  ${ui.muted('Expected a positive number, for example: --dpr 2')}\n`);
+    process.exit(1);
+  }
 
   showBanner();
 
@@ -152,9 +165,12 @@ async function main(): Promise<void> {
   const out: string = args[1] || `./${defaultDir}`;
 
   try {
-    await new FramerExporter(url, path.resolve(out), platformOverride || undefined).run(
-      includeSubpages
-    );
+    await new FramerExporter(
+      url,
+      path.resolve(out),
+      platformOverride || undefined,
+      deviceScaleFactor
+    ).run(includeSubpages);
   } catch (e) {
     const { AntiBotError, formatAntiBotError } = await import('../exporter/anti-bot.js');
     if (e instanceof AntiBotError) {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,7 +1,9 @@
 import type { Config } from '../types.js';
 
 export const CFG: Config = {
-  viewport: { width: 1440, height: 900 },
+  // Crawl at 2x so responsive images resolve to the retina variant the source
+  // site serves; a 1x capture mirrors a softer image than the original.
+  viewport: { width: 1440, height: 900, deviceScaleFactor: 2 },
   timeout: 90000,
   scrollStep: 250,
   scrollDelay: 60,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,9 +1,7 @@
 import type { Config } from '../types.js';
 
 export const CFG: Config = {
-  // Crawl at 2x so responsive images resolve to the retina variant the source
-  // site serves; a 1x capture mirrors a softer image than the original.
-  viewport: { width: 1440, height: 900, deviceScaleFactor: 2 },
+  viewport: { width: 1440, height: 900, deviceScaleFactor: 1 },
   timeout: 90000,
   scrollStep: 250,
   scrollDelay: 60,
@@ -11,7 +9,9 @@ export const CFG: Config = {
   retries: 3,
   dlTimeout: 30000,
   sharedStripDomains: [
-    'sentry.io', 'www.googletagmanager.com', 'connect.facebook.net',
+    'sentry.io',
+    'www.googletagmanager.com',
+    'connect.facebook.net',
     'stats.g.doubleclick.net',
     'google-analytics.com',
   ],

--- a/src/exporter/capture.ts
+++ b/src/exporter/capture.ts
@@ -16,8 +16,20 @@ export async function launchAndCapture(exporter: ExporterContext): Promise<void>
   success('Chromium launched');
 
   exporter.page = await exporter.browser.newPage();
-  await exporter.page.setViewport(CFG.viewport);
-  log('Viewport set to ' + CFG.viewport.width + 'x' + CFG.viewport.height);
+  const viewport = {
+    ...CFG.viewport,
+    deviceScaleFactor: exporter.deviceScaleFactor ?? CFG.viewport.deviceScaleFactor ?? 1,
+  };
+  await exporter.page.setViewport(viewport);
+  log(
+    'Viewport set to ' +
+      viewport.width +
+      'x' +
+      viewport.height +
+      ' at ' +
+      viewport.deviceScaleFactor +
+      'x DPR'
+  );
 
   await exporter.page.setUserAgent(
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' +
@@ -35,7 +47,8 @@ export async function launchAndCapture(exporter: ExporterContext): Promise<void>
   }
 
   let intercepted = 0;
-  let blocked = 0;
+  let trackingBlocked = 0;
+  let platformSkipped = 0;
 
   exporter.page.on('response', async (res) => {
     const url: string = res.url();
@@ -44,7 +57,7 @@ export async function launchAndCapture(exporter: ExporterContext): Promise<void>
     try {
       const host: string = new URL(url).hostname;
       if (allStripDomains.some((d) => host.includes(d))) {
-        blocked++;
+        trackingBlocked++;
         return;
       }
     } catch {
@@ -52,7 +65,7 @@ export async function launchAndCapture(exporter: ExporterContext): Promise<void>
     }
 
     if (exporter.platform.skipAssetUrls?.some((re) => re.test(url))) {
-      blocked++;
+      platformSkipped++;
       return;
     }
 
@@ -72,7 +85,15 @@ export async function launchAndCapture(exporter: ExporterContext): Promise<void>
     timeout: CFG.timeout,
   });
   success('Page loaded (networkidle2)');
-  log('Intercepted ' + intercepted + ' resources, blocked ' + blocked + ' tracking requests');
+  log(
+    'Intercepted ' +
+      intercepted +
+      ' resources, blocked ' +
+      trackingBlocked +
+      ' tracking requests, skipped ' +
+      platformSkipped +
+      ' platform assets'
+  );
 
   log('Checking DOM-based platform detection...');
   const domDetected = await detectByDom(exporter.page);

--- a/src/exporter/capture.ts
+++ b/src/exporter/capture.ts
@@ -51,6 +51,11 @@ export async function launchAndCapture(exporter: ExporterContext): Promise<void>
       return;
     }
 
+    if (exporter.platform.skipAssetUrls?.some((re) => re.test(url))) {
+      blocked++;
+      return;
+    }
+
     exporter.assets.localPathFor(url, exporter.platform);
     try {
       exporter.assets.buffers.set(url, await res.buffer());

--- a/src/exporter/download.ts
+++ b/src/exporter/download.ts
@@ -75,3 +75,63 @@ export async function downloadAll(exporter: ExporterContext): Promise<void> {
   exporter.assets.buffers.clear();
   log('Network buffer cache cleared');
 }
+
+const SIBLING_IMPORT = /(?:import|from)\s*\(?\s*["'`]\.\/([A-Za-z0-9_.-]+\.m?js)["'`]/g;
+const CHUNK_DIRS: string[] = ['scripts/vendor', 'scripts/modules'];
+
+/**
+ * Route and font chunks load lazily, so a single crawl never requests them and
+ * the mirror ends up with dead `import("./chunk.mjs")` calls. Follow those
+ * sibling specifiers from the JS already on disk until the graph closes.
+ */
+export async function downloadLazyChunks(exporter: ExporterContext): Promise<void> {
+  const sourceOf: Map<string, string> = new Map();
+  for (const [url, { localPath }] of exporter.assets.entries) {
+    if (!sourceOf.has(localPath)) sourceOf.set(localPath, url);
+  }
+
+  let frontier: string[] = [...sourceOf.keys()].filter((p) =>
+    CHUNK_DIRS.some((dir) => p.startsWith(dir + '/'))
+  );
+  let added = 0;
+
+  // Each fetched chunk can name more chunks; the graph is shallow in practice.
+  for (let depth = 0; depth < 5 && frontier.length > 0; depth++) {
+    const next: string[] = [];
+
+    for (const localPath of frontier) {
+      let code: string;
+      try {
+        code = await fs.readFile(path.join(exporter.outDir, localPath), 'utf-8');
+      } catch {
+        continue;
+      }
+
+      for (const match of code.matchAll(SIBLING_IMPORT)) {
+        let chunkUrl: string;
+        try {
+          chunkUrl = new URL('./' + match[1], sourceOf.get(localPath)!).href;
+        } catch {
+          continue;
+        }
+        if (exporter.assets.entries.has(chunkUrl)) continue;
+
+        const dest: string | null = exporter.assets.localPathFor(chunkUrl, exporter.platform);
+        if (!dest) continue;
+        sourceOf.set(dest, chunkUrl);
+
+        try {
+          await fs.writeFile(path.join(exporter.outDir, dest), await dlBuffer(chunkUrl));
+          next.push(dest);
+          added++;
+        } catch (e) {
+          warn('Lazy chunk failed: ' + match[1] + ' - ' + (e as Error).message);
+        }
+      }
+    }
+
+    frontier = next;
+  }
+
+  if (added > 0) success('Lazy-loaded chunks resolved: ' + added);
+}

--- a/src/exporter/download.ts
+++ b/src/exporter/download.ts
@@ -34,8 +34,7 @@ export async function downloadAll(exporter: ExporterContext): Promise<void> {
 
         try {
           const buf: Buffer | undefined =
-            exporter.assets.buffers.get(url) ||
-            exporter.assets.buffers.get(url.split('?')[0]);
+            exporter.assets.buffers.get(url) || exporter.assets.buffers.get(url.split('?')[0]);
           if (buf) {
             await fs.writeFile(dest, buf);
             cached++;
@@ -47,10 +46,7 @@ export async function downloadAll(exporter: ExporterContext): Promise<void> {
           }
         } catch (e) {
           fail++;
-          if (
-            !url.includes('framer.com/edit') &&
-            !url.includes('framerstatic.com/editorbar')
-          ) {
+          if (!url.includes('framer.com/edit') && !url.includes('framerstatic.com/editorbar')) {
             warn('Download failed: ' + path.basename(localPath) + ' - ' + (e as Error).message);
           }
         }
@@ -67,7 +63,9 @@ export async function downloadAll(exporter: ExporterContext): Promise<void> {
 
   await pool(tasks, CFG.concurrency);
 
-  success('Downloads complete: ' + ok + ' succeeded, ' + cached + ' from cache, ' + fail + ' failed');
+  success(
+    'Downloads complete: ' + ok + ' succeeded, ' + cached + ' from cache, ' + fail + ' failed'
+  );
 
   const totalBytes: number = [...exporter.assets.entries.values()].length;
   log('Total unique assets written to disk: ' + totalBytes);
@@ -77,7 +75,7 @@ export async function downloadAll(exporter: ExporterContext): Promise<void> {
 }
 
 const SIBLING_IMPORT = /(?:import|from)\s*\(?\s*["'`]\.\/([A-Za-z0-9_.-]+\.m?js)["'`]/g;
-const CHUNK_DIRS: string[] = ['scripts/vendor', 'scripts/modules'];
+const MAX_CHUNK_DEPTH = 5;
 
 /**
  * Route and font chunks load lazily, so a single crawl never requests them and
@@ -85,26 +83,29 @@ const CHUNK_DIRS: string[] = ['scripts/vendor', 'scripts/modules'];
  * sibling specifiers from the JS already on disk until the graph closes.
  */
 export async function downloadLazyChunks(exporter: ExporterContext): Promise<void> {
+  const chunkDirs = exporter.platform.lazyChunkDirs;
+  if (!chunkDirs?.length) return;
+
   const sourceOf: Map<string, string> = new Map();
   for (const [url, { localPath }] of exporter.assets.entries) {
     if (!sourceOf.has(localPath)) sourceOf.set(localPath, url);
   }
 
   let frontier: string[] = [...sourceOf.keys()].filter((p) =>
-    CHUNK_DIRS.some((dir) => p.startsWith(dir + '/'))
+    chunkDirs.some((dir) => p.startsWith(dir + '/'))
   );
   let added = 0;
 
   // Each fetched chunk can name more chunks; the graph is shallow in practice.
-  for (let depth = 0; depth < 5 && frontier.length > 0; depth++) {
+  for (let depth = 0; depth < MAX_CHUNK_DEPTH && frontier.length > 0; depth++) {
     const next: string[] = [];
 
-    for (const localPath of frontier) {
+    const tasks = frontier.map((localPath) => async (): Promise<void> => {
       let code: string;
       try {
         code = await fs.readFile(path.join(exporter.outDir, localPath), 'utf-8');
       } catch {
-        continue;
+        return;
       }
 
       for (const match of code.matchAll(SIBLING_IMPORT)) {
@@ -128,10 +129,20 @@ export async function downloadLazyChunks(exporter: ExporterContext): Promise<voi
           warn('Lazy chunk failed: ' + match[1] + ' - ' + (e as Error).message);
         }
       }
-    }
+    });
+    await pool(tasks, CFG.concurrency);
 
     frontier = next;
   }
 
+  if (frontier.length > 0) {
+    warn(
+      'Lazy chunk traversal stopped at depth ' +
+        MAX_CHUNK_DEPTH +
+        ' with ' +
+        frontier.length +
+        ' chunks left to inspect'
+    );
+  }
   if (added > 0) success('Lazy-loaded chunks resolved: ' + added);
 }

--- a/src/exporter/index.ts
+++ b/src/exporter/index.ts
@@ -7,7 +7,7 @@ import { dlBuffer } from '../network/download.js';
 import { info, log, success, setCooking } from '../logger/index.js';
 import { launchAndCapture, captureSubpage, closeBrowser } from './capture.js';
 import { AntiBotError } from './anti-bot.js';
-import { downloadAll } from './download.js';
+import { downloadAll, downloadLazyChunks } from './download.js';
 import { buildOutput } from './output.js';
 import { printSummary } from './summary.js';
 import { runAiPromptAssistant } from '../ai/prompt-assistant.js';
@@ -143,6 +143,9 @@ export class FramerExporter implements ExporterContext {
 
       this.cooking.update('Downloading assets...');
       await downloadAll(this);
+
+      this.cooking.update('Resolving lazy-loaded chunks...');
+      await downloadLazyChunks(this);
 
       this.cooking.update('Building output...');
       await buildOutput(this);

--- a/src/exporter/index.ts
+++ b/src/exporter/index.ts
@@ -66,9 +66,15 @@ export class FramerExporter implements ExporterContext {
   prettyPrint: boolean;
   platform: PlatformHandler;
   cooking?: CookingSpinner;
+  deviceScaleFactor?: number;
   subpages: Map<string, string> = new Map();
 
-  constructor(siteUrl: string, outDir: string, platformOverride?: PlatformType) {
+  constructor(
+    siteUrl: string,
+    outDir: string,
+    platformOverride?: PlatformType,
+    deviceScaleFactor?: number
+  ) {
     this.siteUrl = siteUrl;
     this.outDir = outDir;
     this.assets = new AssetMap();
@@ -76,6 +82,7 @@ export class FramerExporter implements ExporterContext {
     this.page = null;
     this.ssrHTML = '';
     this.prettyPrint = true;
+    this.deviceScaleFactor = deviceScaleFactor;
 
     if (platformOverride && platformOverride !== 'unknown') {
       this.platform = getPlatformByName(platformOverride);
@@ -91,6 +98,7 @@ export class FramerExporter implements ExporterContext {
     info('Source   : ' + chalk.underline(this.siteUrl));
     info('Output   : ' + ui.primary(this.outDir));
     info('Platform : ' + ui.primary(this.platform.displayName));
+    info('DPR      : ' + ui.primary(String(this.deviceScaleFactor || 1)));
     if (includeSubpages) {
       info('Subpages : ' + ui.success('enabled'));
     }

--- a/src/exporter/index.ts
+++ b/src/exporter/index.ts
@@ -66,6 +66,7 @@ export class FramerExporter implements ExporterContext {
   prettyPrint: boolean;
   platform: PlatformHandler;
   cooking?: CookingSpinner;
+  subpages: Map<string, string> = new Map();
 
   constructor(siteUrl: string, outDir: string, platformOverride?: PlatformType) {
     this.siteUrl = siteUrl;
@@ -212,8 +213,27 @@ export class FramerExporter implements ExporterContext {
       return Array.from(hrefs);
     }, baseHost);
 
-    log('Found ' + links.length + ' sub-page links');
-    const uniqueLinks = [...new Set(links)].slice(0, 50);
+    // Framer-style SPAs drop their route anchors during hydration, so the
+    // rendered DOM alone misses real pages the SSR markup still links to.
+    const ssrLinks: string[] = [];
+    for (const m of this.ssrHTML.matchAll(/<a\b[^>]*\shref=["']([^"']+)["']/gi)) {
+      const href = m[1];
+      if (/^(javascript:|mailto:|tel:|#)/i.test(href)) continue;
+      try {
+        const u = new URL(href, this.siteUrl);
+        if (
+          u.protocol.startsWith('http') &&
+          u.hostname.replace(/^www\./, '') === baseHost &&
+          u.pathname !== '/' &&
+          u.pathname !== ''
+        ) {
+          ssrLinks.push(u.href.split('#')[0]);
+        }
+      } catch {}
+    }
+
+    const uniqueLinks = [...new Set([...links, ...ssrLinks])].slice(0, 50);
+    log('Found ' + uniqueLinks.length + ' sub-page links');
 
     if (uniqueLinks.length === 0) {
       log('No sub-pages to crawl');
@@ -234,6 +254,7 @@ export class FramerExporter implements ExporterContext {
         const filepath = path.join(this.outDir, 'subpages', filename);
 
         await fs.writeFile(filepath, html, 'utf-8');
+        this.subpages.set(link, filename);
         log('  Saved: subpages/' + filename);
       } catch (e) {
         log('  Skipped ' + link + ': ' + (e as Error).message);

--- a/src/exporter/output.ts
+++ b/src/exporter/output.ts
@@ -126,6 +126,13 @@ function stripSrcsetCdnUrls(html: string): string {
   return html;
 }
 
+function applyRewritePatterns(text: string, exporter: ExporterContext): string {
+  for (const { from, to } of exporter.platform.rewritePatterns || []) {
+    text = text.replace(new RegExp(from.source, from.flags), to);
+  }
+  return text;
+}
+
 /** Map crawled sub-page URLs to their exported filenames, keyed by pathname. */
 function subpageRoutes(exporter: ExporterContext): Map<string, string> {
   const routes = new Map<string, string>();
@@ -148,15 +155,17 @@ function rewriteInternalLinks(
 
   return html.replace(/href="([^"]+)"/g, (match: string, href: string) => {
     if (/^(javascript:|mailto:|tel:|#|data:)/i.test(href)) return match;
-    let pathname: string;
+    let target: URL;
     try {
-      pathname = new URL(href, exporter.siteUrl).pathname.replace(/\/+$/, '');
+      target = new URL(href, exporter.siteUrl);
     } catch {
       return match;
     }
-    const filename = routes.get(pathname);
+    const filename = routes.get(target.pathname.replace(/\/+$/, ''));
     if (!filename) return match;
-    return `href="${fromSubpages ? filename : 'subpages/' + filename}"`;
+    // The hash selects a section on the destination page, so it has to survive.
+    const local: string = (fromSubpages ? filename : 'subpages/' + filename) + target.hash;
+    return `href="${local}"`;
   });
 }
 
@@ -180,9 +189,7 @@ async function buildSubpages(exporter: ExporterContext): Promise<void> {
         html = html.replace(new RegExp(pattern.source, pattern.flags), '');
       }
       html = exporter.assets.rewrite(html, 'subpages');
-      for (const { from, to } of exporter.platform.rewriteUrlPatterns || []) {
-        html = html.replace(new RegExp(from.source, from.flags), to);
-      }
+      html = applyRewritePatterns(html, exporter);
       html = stripSrcsetCdnUrls(html);
       html = rewriteInternalLinks(html, exporter, routes, true);
       html = html.replace(
@@ -269,11 +276,10 @@ export async function buildOutput(exporter: ExporterContext): Promise<void> {
   html = exporter.assets.rewrite(html, '');
   log('HTML rewrite delta: ' + (html.length - beforeRewrite) + ' chars');
 
-  if (exporter.platform.rewriteUrlPatterns && exporter.platform.rewriteUrlPatterns.length > 0) {
-    for (const { from, to } of exporter.platform.rewriteUrlPatterns) {
-      html = html.replace(new RegExp(from.source, from.flags), to);
-    }
-    log('Applied ' + exporter.platform.rewriteUrlPatterns.length + ' custom URL rewrites');
+  const patternCount: number = exporter.platform.rewritePatterns?.length || 0;
+  if (patternCount > 0) {
+    html = applyRewritePatterns(html, exporter);
+    log('Applied ' + patternCount + ' custom rewrites');
   }
 
   exporter.cooking?.update('Cleaning srcset references...');
@@ -326,6 +332,7 @@ async function rewriteDownloadedFiles(exporter: ExporterContext): Promise<void> 
         let content: string = await fs.readFile(filePath, 'utf-8');
         const before: string = content;
         content = exporter.assets.rewrite(content, dir);
+        content = applyRewritePatterns(content, exporter);
         if (content !== before) {
           await fs.writeFile(filePath, content);
           rewritten++;

--- a/src/exporter/output.ts
+++ b/src/exporter/output.ts
@@ -126,10 +126,23 @@ function stripSrcsetCdnUrls(html: string): string {
   return html;
 }
 
-function applyRewritePatterns(text: string, exporter: ExporterContext): string {
-  for (const { from, to } of exporter.platform.rewritePatterns || []) {
-    text = text.replace(new RegExp(from.source, from.flags), to);
-  }
+type RewritePattern = { from: RegExp; to: string };
+
+interface RewriteReport {
+  patterns: RewritePattern[];
+  matched: Set<number>;
+}
+
+function rewritePatterns(exporter: ExporterContext): RewritePattern[] {
+  return exporter.platform.rewritePatterns ?? exporter.platform.rewriteUrlPatterns ?? [];
+}
+
+function applyRewritePatterns(text: string, report: RewriteReport): string {
+  report.patterns.forEach(({ from, to }, index) => {
+    const pattern = new RegExp(from.source, from.flags);
+    if (new RegExp(from.source, from.flags).test(text)) report.matched.add(index);
+    text = text.replace(pattern, to);
+  });
   return text;
 }
 
@@ -145,57 +158,90 @@ function subpageRoutes(exporter: ExporterContext): Map<string, string> {
 }
 
 /** Point internal links at the exported HTML files instead of live routes. */
-function rewriteInternalLinks(
+export function rewriteInternalLinks(
   html: string,
-  exporter: ExporterContext,
+  siteUrl: string,
   routes: Map<string, string>,
   fromSubpages: boolean
 ): string {
-  if (routes.size === 0) return html;
+  const source = new URL(siteUrl);
+  const sourceHost = source.hostname.replace(/^www\./, '');
+  const rootPath = source.pathname.replace(/\/+$/, '') || '/';
 
-  return html.replace(/href="([^"]+)"/g, (match: string, href: string) => {
-    if (/^(javascript:|mailto:|tel:|#|data:)/i.test(href)) return match;
-    let target: URL;
-    try {
-      target = new URL(href, exporter.siteUrl);
-    } catch {
-      return match;
+  return html.replace(
+    /<(?!link\b)([^>]*?\bhref\s*=\s*)(["'])(.*?)\2/gi,
+    (match: string, prefix: string, quote: string, href: string) => {
+      if (/^(javascript:|mailto:|tel:|#|data:)/i.test(href)) return match;
+      let target: URL;
+      try {
+        target = new URL(href, siteUrl);
+      } catch {
+        return match;
+      }
+
+      if (target.hostname.replace(/^www\./, '') !== sourceHost) return match;
+
+      const targetPath = target.pathname.replace(/\/+$/, '') || '/';
+      if (fromSubpages && targetPath === rootPath) {
+        return `<${prefix}${quote}../index.html${target.hash}${quote}`;
+      }
+
+      const filename = routes.get(targetPath);
+      if (!filename) return match;
+      // The hash selects a section on the destination page, so it has to survive.
+      const local: string = (fromSubpages ? filename : 'subpages/' + filename) + target.hash;
+      return `<${prefix}${quote}${local}${quote}`;
     }
-    const filename = routes.get(target.pathname.replace(/\/+$/, ''));
-    if (!filename) return match;
-    // The hash selects a section on the destination page, so it has to survive.
-    const local: string = (fromSubpages ? filename : 'subpages/' + filename) + target.hash;
-    return `href="${local}"`;
-  });
+  );
 }
 
-async function buildSubpages(exporter: ExporterContext): Promise<void> {
+function processHtml(
+  html: string,
+  exporter: ExporterContext,
+  pageUrl: string,
+  fromDir: string,
+  routes: Map<string, string>,
+  fromSubpages: boolean,
+  report: RewriteReport
+): string {
+  html = stripIntegrityAndCors(html);
+  html = processSEO(html, pageUrl);
+  for (const sel of exporter.platform.stripSelectors) html = stripBySelector(html, sel);
+  for (const pattern of exporter.platform.stripPatterns) {
+    html = html.replace(new RegExp(pattern.source, pattern.flags), '');
+  }
+  for (const pattern of exporter.platform.stripScripts || []) {
+    html = html.replace(new RegExp(pattern.source, pattern.flags), '');
+  }
+
+  if (exporter.platform.postCapture) {
+    try {
+      html = exporter.platform.postCapture(html, exporter);
+    } catch (e) {
+      warn('postCapture hook failed for ' + pageUrl + ': ' + (e as Error).message);
+    }
+  }
+
+  html = exporter.assets.rewrite(html, fromDir);
+  html = applyRewritePatterns(html, report);
+  html = stripSrcsetCdnUrls(html);
+  return rewriteInternalLinks(html, exporter.siteUrl, routes, fromSubpages);
+}
+
+async function buildSubpages(
+  exporter: ExporterContext,
+  routes: Map<string, string>,
+  report: RewriteReport
+): Promise<void> {
   if (exporter.subpages.size === 0) return;
 
-  const routes = subpageRoutes(exporter);
-  const rootPath: string = new URL(exporter.siteUrl).pathname.replace(/\/+$/, '') || '/';
   let built = 0;
 
-  for (const filename of exporter.subpages.values()) {
+  for (const [pageUrl, filename] of exporter.subpages) {
     const filePath: string = path.join(exporter.outDir, 'subpages', filename);
     try {
       let html: string = await fs.readFile(filePath, 'utf-8');
-      html = stripIntegrityAndCors(html);
-      for (const sel of exporter.platform.stripSelectors) html = stripBySelector(html, sel);
-      for (const pattern of exporter.platform.stripPatterns) {
-        html = html.replace(new RegExp(pattern.source, pattern.flags), '');
-      }
-      for (const pattern of exporter.platform.stripScripts || []) {
-        html = html.replace(new RegExp(pattern.source, pattern.flags), '');
-      }
-      html = exporter.assets.rewrite(html, 'subpages');
-      html = applyRewritePatterns(html, exporter);
-      html = stripSrcsetCdnUrls(html);
-      html = rewriteInternalLinks(html, exporter, routes, true);
-      html = html.replace(
-        new RegExp(`href="${escapeRegex(rootPath === '/' ? '/' : rootPath)}"`, 'g'),
-        'href="../index.html"'
-      );
+      html = processHtml(html, exporter, pageUrl, 'subpages', routes, true, report);
       await fs.writeFile(filePath, html, 'utf-8');
       built++;
     } catch (e) {
@@ -217,79 +263,17 @@ export async function buildOutput(exporter: ExporterContext): Promise<void> {
     return;
   }
 
-  exporter.cooking?.update('Removing integrity checks...');
-  const beforeIntegrity: number = html.length;
-  html = stripIntegrityAndCors(html);
-  log('Stripped integrity/crossorigin/preconnect (' + (beforeIntegrity - html.length) + ' chars)');
-  success('Integrity and CORS restrictions removed');
+  const routes = subpageRoutes(exporter);
+  const report: RewriteReport = { patterns: rewritePatterns(exporter), matched: new Set() };
+  exporter.cooking?.update('Processing exported HTML...');
+  html = processHtml(html, exporter, exporter.siteUrl, '', routes, false, report);
+  success('Index HTML pipeline complete');
 
-  if (typeof processSEO === 'function') {
-    exporter.cooking?.update('Optimizing SEO...');
-    html = processSEO(html, exporter.siteUrl);
-    success('SEO meta tags optimized');
-  }
-
-  log('Stripping ' + exporter.platform.stripSelectors.length + ' selectors:');
-  for (const sel of exporter.platform.stripSelectors) {
-    const before: number = html.length;
-    html = stripBySelector(html, sel);
-    const removed: number = before - html.length;
-    if (removed > 0) {
-      log('  Stripped ' + sel + ' (' + removed + ' chars removed)');
-    }
-  }
-
-  log('Applying ' + exporter.platform.stripPatterns.length + ' regex patterns...');
-  for (const pattern of exporter.platform.stripPatterns) {
-    const before: number = html.length;
-    html = html.replace(new RegExp(pattern.source, pattern.flags), '');
-    const removed: number = before - html.length;
-    if (removed > 0) {
-      log('  Pattern removed ' + removed + ' chars');
-    }
-  }
-  if (exporter.platform.stripScripts && exporter.platform.stripScripts.length > 0) {
-    log('Applying ' + exporter.platform.stripScripts.length + ' script-strip patterns...');
-    for (const pattern of exporter.platform.stripScripts) {
-      const before: number = html.length;
-      html = html.replace(new RegExp(pattern.source, pattern.flags), '');
-      const removed: number = before - html.length;
-      if (removed > 0) log('  Script pattern removed ' + removed + ' chars');
-    }
-  }
-
-  success('Platform badges and tracking stripped');
-
-  if (exporter.platform.postCapture) {
-    try {
-      const before: number = html.length;
-      html = exporter.platform.postCapture(html, exporter);
-      log('postCapture hook applied (delta ' + (html.length - before) + ' chars)');
-    } catch (e) {
-      warn('postCapture hook failed: ' + (e as Error).message);
-    }
-  }
-
-  exporter.cooking?.update('Rewriting asset URLs...');
-  log('Rewriting ' + exporter.assets.entries.size + ' CDN URLs to local paths...');
-  const beforeRewrite: number = html.length;
-  html = exporter.assets.rewrite(html, '');
-  log('HTML rewrite delta: ' + (html.length - beforeRewrite) + ' chars');
-
-  const patternCount: number = exporter.platform.rewritePatterns?.length || 0;
-  if (patternCount > 0) {
-    html = applyRewritePatterns(html, exporter);
-    log('Applied ' + patternCount + ' custom rewrites');
-  }
-
-  exporter.cooking?.update('Cleaning srcset references...');
-  html = stripSrcsetCdnUrls(html);
-  log('Cleaned remaining CDN URLs from srcset attributes');
-
-  html = rewriteInternalLinks(html, exporter, subpageRoutes(exporter), false);
-
-  await rewriteDownloadedFiles(exporter);
-  await buildSubpages(exporter);
+  await rewriteDownloadedFiles(exporter, report);
+  await buildSubpages(exporter, routes, report);
+  report.patterns.forEach(({ from }, index) => {
+    if (!report.matched.has(index)) warn('Rewrite pattern matched nothing: ' + from.toString());
+  });
   success('All URLs rewritten to local paths');
 
   exporter.cooking?.update('Pretty-printing JS files...');
@@ -310,7 +294,10 @@ export async function buildOutput(exporter: ExporterContext): Promise<void> {
   success('Output build complete');
 }
 
-async function rewriteDownloadedFiles(exporter: ExporterContext): Promise<void> {
+async function rewriteDownloadedFiles(
+  exporter: ExporterContext,
+  report: RewriteReport
+): Promise<void> {
   const dirs: string[] = ['scripts/vendor', 'scripts/modules', 'styles'];
   let rewritten = 0;
 
@@ -332,7 +319,7 @@ async function rewriteDownloadedFiles(exporter: ExporterContext): Promise<void> 
         let content: string = await fs.readFile(filePath, 'utf-8');
         const before: string = content;
         content = exporter.assets.rewrite(content, dir);
-        content = applyRewritePatterns(content, exporter);
+        content = applyRewritePatterns(content, report);
         if (content !== before) {
           await fs.writeFile(filePath, content);
           rewritten++;

--- a/src/exporter/output.ts
+++ b/src/exporter/output.ts
@@ -126,6 +126,79 @@ function stripSrcsetCdnUrls(html: string): string {
   return html;
 }
 
+/** Map crawled sub-page URLs to their exported filenames, keyed by pathname. */
+function subpageRoutes(exporter: ExporterContext): Map<string, string> {
+  const routes = new Map<string, string>();
+  for (const [url, filename] of exporter.subpages) {
+    try {
+      routes.set(new URL(url).pathname.replace(/\/+$/, ''), filename);
+    } catch {}
+  }
+  return routes;
+}
+
+/** Point internal links at the exported HTML files instead of live routes. */
+function rewriteInternalLinks(
+  html: string,
+  exporter: ExporterContext,
+  routes: Map<string, string>,
+  fromSubpages: boolean
+): string {
+  if (routes.size === 0) return html;
+
+  return html.replace(/href="([^"]+)"/g, (match: string, href: string) => {
+    if (/^(javascript:|mailto:|tel:|#|data:)/i.test(href)) return match;
+    let pathname: string;
+    try {
+      pathname = new URL(href, exporter.siteUrl).pathname.replace(/\/+$/, '');
+    } catch {
+      return match;
+    }
+    const filename = routes.get(pathname);
+    if (!filename) return match;
+    return `href="${fromSubpages ? filename : 'subpages/' + filename}"`;
+  });
+}
+
+async function buildSubpages(exporter: ExporterContext): Promise<void> {
+  if (exporter.subpages.size === 0) return;
+
+  const routes = subpageRoutes(exporter);
+  const rootPath: string = new URL(exporter.siteUrl).pathname.replace(/\/+$/, '') || '/';
+  let built = 0;
+
+  for (const filename of exporter.subpages.values()) {
+    const filePath: string = path.join(exporter.outDir, 'subpages', filename);
+    try {
+      let html: string = await fs.readFile(filePath, 'utf-8');
+      html = stripIntegrityAndCors(html);
+      for (const sel of exporter.platform.stripSelectors) html = stripBySelector(html, sel);
+      for (const pattern of exporter.platform.stripPatterns) {
+        html = html.replace(new RegExp(pattern.source, pattern.flags), '');
+      }
+      for (const pattern of exporter.platform.stripScripts || []) {
+        html = html.replace(new RegExp(pattern.source, pattern.flags), '');
+      }
+      html = exporter.assets.rewrite(html, 'subpages');
+      for (const { from, to } of exporter.platform.rewriteUrlPatterns || []) {
+        html = html.replace(new RegExp(from.source, from.flags), to);
+      }
+      html = stripSrcsetCdnUrls(html);
+      html = rewriteInternalLinks(html, exporter, routes, true);
+      html = html.replace(
+        new RegExp(`href="${escapeRegex(rootPath === '/' ? '/' : rootPath)}"`, 'g'),
+        'href="../index.html"'
+      );
+      await fs.writeFile(filePath, html, 'utf-8');
+      built++;
+    } catch (e) {
+      warn('Sub-page post-processing skipped: ' + filename + ' - ' + (e as Error).message);
+    }
+  }
+
+  success('Sub-pages linked to local assets: ' + built + '/' + exporter.subpages.size);
+}
+
 export async function buildOutput(exporter: ExporterContext): Promise<void> {
   exporter.cooking?.update('Stripping platform badges...');
   log('Starting HTML post-processing...');
@@ -207,7 +280,10 @@ export async function buildOutput(exporter: ExporterContext): Promise<void> {
   html = stripSrcsetCdnUrls(html);
   log('Cleaned remaining CDN URLs from srcset attributes');
 
+  html = rewriteInternalLinks(html, exporter, subpageRoutes(exporter), false);
+
   await rewriteDownloadedFiles(exporter);
+  await buildSubpages(exporter);
   success('All URLs rewritten to local paths');
 
   exporter.cooking?.update('Pretty-printing JS files...');

--- a/src/platforms/framer.ts
+++ b/src/platforms/framer.ts
@@ -39,7 +39,27 @@ export const framer: PlatformHandler = {
 
   // The editor bar builds its iframe URL from import.meta.url, so a mirrored
   // copy points at the export's own script directory and 404s in a loop.
-  skipAssetUrls: [/\/init\.mjs(\?|$)/, /\/editorbar\.[^/]*\.mjs/, /\/EditButton-[^/]*\.mjs/],
+  skipAssetUrls: [
+    /^https:\/\/(?:www\.)?framer\.com\/edit(?:[/?]|$)/,
+    /\/init\.mjs(\?|$)/,
+    /\/editorbar\.[^/]*\.mjs/,
+    /\/EditButton-[^/]*\.mjs/,
+  ],
+
+  rewritePatterns: [
+    // The editor bar is Framer chrome, not site content: give the loader an
+    // inert module so a mirror never reaches back out to framer.com.
+    {
+      from: /https:\/\/(?:www\.)?framer\.com\/edit\/init\.mjs/g,
+      to: 'data:text/javascript,export%20const%20createEditorBar=()=>()=>null',
+    },
+    // The badge markup is stripped from the HTML, so its bootstrap would call
+    // hydrateRoot with a null container and kill the rest of the page scripts.
+    {
+      from: /\(function\(\)\{[\w$]+&&[\w$]+\(\(\)=>\{[\s\S]{0,200}?__framer-badge-container[\s\S]{0,300}?\}\)\}\)\(\)/g,
+      to: '',
+    },
+  ],
 
   mapAssetDir(host: string, pathname: string, ext: string): string | null {
     if (host.includes('framerusercontent.com')) {

--- a/src/platforms/framer.ts
+++ b/src/platforms/framer.ts
@@ -39,12 +39,15 @@ export const framer: PlatformHandler = {
 
   // The editor bar builds its iframe URL from import.meta.url, so a mirrored
   // copy points at the export's own script directory and 404s in a loop.
+  // Keep these regexes non-global because capture calls RegExp.test repeatedly.
   skipAssetUrls: [
     /^https:\/\/(?:www\.)?framer\.com\/edit(?:[/?]|$)/,
-    /\/init\.mjs(\?|$)/,
-    /\/editorbar\.[^/]*\.mjs/,
-    /\/EditButton-[^/]*\.mjs/,
+    /^https:\/\/(?:[^/]+\.)*(?:framer\.com|framerstatic\.com|framerusercontent\.com|framercanvas\.com)\/[^?]*\/init\.mjs(?:\?|$)/,
+    /^https:\/\/(?:[^/]+\.)*(?:framer\.com|framerstatic\.com|framerusercontent\.com|framercanvas\.com)\/[^?]*\/editorbar\.[^/]*\.mjs(?:\?|$)/,
+    /^https:\/\/(?:[^/]+\.)*(?:framer\.com|framerstatic\.com|framerusercontent\.com|framercanvas\.com)\/[^?]*\/EditButton-[^/]*\.mjs(?:\?|$)/,
   ],
+
+  lazyChunkDirs: ['scripts/vendor', 'scripts/modules'],
 
   rewritePatterns: [
     // The editor bar is Framer chrome, not site content: give the loader an

--- a/src/platforms/framer.ts
+++ b/src/platforms/framer.ts
@@ -31,11 +31,15 @@ export const framer: PlatformHandler = {
 
   stripPatterns: [
     /<div id="__framer-badge-container"[^>]*><\/div>/g,
-    /<script>try\{if\(localStorage\.get\("__framer_force_showing_editorbar_since"\)\)[^<]*<\/script>/g,
+    /<script>try\{if\(localStorage\.getItem\("__framer_force_showing_editorbar_since"\)\)[^<]*<\/script>/g,
   ],
 
   hydrationTimeout: 10000,
   needsHydrationCheck: true,
+
+  // The editor bar builds its iframe URL from import.meta.url, so a mirrored
+  // copy points at the export's own script directory and 404s in a loop.
+  skipAssetUrls: [/\/init\.mjs(\?|$)/, /\/editorbar\.[^/]*\.mjs/, /\/EditButton-[^/]*\.mjs/],
 
   mapAssetDir(host: string, pathname: string, ext: string): string | null {
     if (host.includes('framerusercontent.com')) {

--- a/src/platforms/types.ts
+++ b/src/platforms/types.ts
@@ -88,6 +88,8 @@ export interface PlatformHandler {
 
   // ── assets ────────────────────────────────────────────────────────────────
   mapAssetDir(host: string, pathname: string, ext: string): string | null;
+  /** Asset URLs that must never be mirrored (editor chrome, beacons). */
+  skipAssetUrls?: RegExp[];
   /** Extra string/regex URL rewrites applied to HTML and downloaded text files. */
   rewriteUrlPatterns?: Array<{ from: RegExp; to: string }>;
 

--- a/src/platforms/types.ts
+++ b/src/platforms/types.ts
@@ -90,8 +90,12 @@ export interface PlatformHandler {
   mapAssetDir(host: string, pathname: string, ext: string): string | null;
   /** Asset URLs that must never be mirrored (editor chrome, beacons). */
   skipAssetUrls?: RegExp[];
+  /** Directories whose downloaded JS may reference unrequested sibling chunks. */
+  lazyChunkDirs?: string[];
   /** Extra regex rewrites applied to the exported HTML and to mirrored JS/CSS. */
   rewritePatterns?: Array<{ from: RegExp; to: string }>;
+  /** @deprecated Use rewritePatterns. */
+  rewriteUrlPatterns?: Array<{ from: RegExp; to: string }>;
 
   // ── lifecycle hooks (all optional, no-op for the frozen trio) ─────────────
   /** Runs on the live page before the hydration wait (e.g. dismiss overlays). */

--- a/src/platforms/types.ts
+++ b/src/platforms/types.ts
@@ -90,8 +90,8 @@ export interface PlatformHandler {
   mapAssetDir(host: string, pathname: string, ext: string): string | null;
   /** Asset URLs that must never be mirrored (editor chrome, beacons). */
   skipAssetUrls?: RegExp[];
-  /** Extra string/regex URL rewrites applied to HTML and downloaded text files. */
-  rewriteUrlPatterns?: Array<{ from: RegExp; to: string }>;
+  /** Extra regex rewrites applied to the exported HTML and to mirrored JS/CSS. */
+  rewritePatterns?: Array<{ from: RegExp; to: string }>;
 
   // ── lifecycle hooks (all optional, no-op for the frozen trio) ─────────────
   /** Runs on the live page before the hydration wait (e.g. dismiss overlays). */

--- a/src/server/template.ts
+++ b/src/server/template.ts
@@ -45,8 +45,11 @@ const server = http.createServer((req, res) => {
   const serveFile = (pathToFile) => {
     fs.readFile(pathToFile, (err, data) => {
       if (err) {
-        // SPA Fallback: if it's not a file, serve index.html
         if (url !== '/index.html' && !path.extname(url)) {
+          // Route paths map to their exported sub-page, then fall back to the SPA shell.
+          const slug = url.replace(/^\\/+|\\/+$/g, '').replace(/[^a-zA-Z0-9_-]/g, '_').replace(/_+/g, '_');
+          const subpage = path.join(ROOT, 'subpages', slug + '.html');
+          if (slug && fs.existsSync(subpage)) return serveFile(subpage);
           return serveFile(path.join(ROOT, 'index.html'));
         }
         res.writeHead(404);

--- a/src/server/template.ts
+++ b/src/server/template.ts
@@ -42,16 +42,10 @@ const server = http.createServer((req, res) => {
     return;
   }
 
-  const serveFile = (pathToFile) => {
+  const serveFile = (pathToFile, onMissing) => {
     fs.readFile(pathToFile, (err, data) => {
       if (err) {
-        if (url !== '/index.html' && !path.extname(url)) {
-          // Route paths map to their exported sub-page, then fall back to the SPA shell.
-          const slug = url.replace(/^\\/+|\\/+$/g, '').replace(/[^a-zA-Z0-9_-]/g, '_').replace(/_+/g, '_');
-          const subpage = path.join(ROOT, 'subpages', slug + '.html');
-          if (slug && fs.existsSync(subpage)) return serveFile(subpage);
-          return serveFile(path.join(ROOT, 'index.html'));
-        }
+        if (onMissing) return onMissing();
         res.writeHead(404);
         res.end('Not found');
         return;
@@ -66,6 +60,16 @@ const server = http.createServer((req, res) => {
       res.end(data);
     });
   };
+
+  if (url !== '/index.html' && !path.extname(url)) {
+    // Route paths map to their exported sub-page, then fall back to the SPA shell.
+    const slug = url.replace(/^\\/+|\\/+$/g, '').replace(/[^a-zA-Z0-9_-]/g, '_').replace(/_+/g, '_');
+    const serveIndex = () => serveFile(path.join(ROOT, 'index.html'));
+    if (slug) {
+      return serveFile(path.join(ROOT, 'subpages', slug + '.html'), serveIndex);
+    }
+    return serveIndex();
+  }
 
   serveFile(filePath);
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,4 +24,6 @@ export interface ExporterContext {
   prettyPrint?: boolean;
   platform: PlatformHandler;
   cooking?: CookingSpinner;
+  /** Crawled sub-page URL -> filename inside subpages/. */
+  subpages: Map<string, string>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ import type { PlatformHandler } from './platforms/types.js';
 import type { CookingSpinner } from './cli/cooking.js';
 
 export interface Config {
-  viewport: { width: number; height: number };
+  viewport: { width: number; height: number; deviceScaleFactor: number };
   timeout: number;
   scrollStep: number;
   scrollDelay: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ import type { PlatformHandler } from './platforms/types.js';
 import type { CookingSpinner } from './cli/cooking.js';
 
 export interface Config {
-  viewport: { width: number; height: number; deviceScaleFactor: number };
+  viewport: { width: number; height: number; deviceScaleFactor?: number };
   timeout: number;
   scrollStep: number;
   scrollDelay: number;
@@ -24,6 +24,7 @@ export interface ExporterContext {
   prettyPrint?: boolean;
   platform: PlatformHandler;
   cooking?: CookingSpinner;
+  deviceScaleFactor?: number;
   /** Crawled sub-page URL -> filename inside subpages/. */
   subpages: Map<string, string>;
 }

--- a/tests/unit/rewrite.test.ts
+++ b/tests/unit/rewrite.test.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { AssetMap, replaceUrl } from '../../src/assets/asset-map.js';
+import { buildOutput, rewriteInternalLinks } from '../../src/exporter/output.js';
+import { framer } from '../../src/platforms/framer.js';
+import type { PlatformHandler } from '../../src/platforms/types.js';
+import type { ExporterContext } from '../../src/types.js';
+
+test('replaceUrl skips a URL used only as a deeper path prefix', () => {
+  const source = 'https://framer.com/edit https://framer.com/edit/init.mjs';
+
+  assert.equal(
+    replaceUrl(source, 'https://framer.com/edit', 'assets/edit'),
+    'assets/edit https://framer.com/edit/init.mjs'
+  );
+});
+
+test('replaceUrl rewrites adjacent query and encoded forms', () => {
+  assert.equal(replaceUrl('x?a=1&amp;b=2', 'x?a=1&amp;b=2', './asset'), './asset');
+});
+
+test('rewriteInternalLinks handles both quote styles and keeps fragments', () => {
+  const routes = new Map([['/about', 'about.html']]);
+  const html = `<a href='/about#team'>About</a><a href="https://www.example.com/about">Again</a>`;
+
+  assert.equal(
+    rewriteInternalLinks(html, 'https://example.com/', routes, false),
+    `<a href='subpages/about.html#team'>About</a><a href="subpages/about.html">Again</a>`
+  );
+});
+
+test('rewriteInternalLinks leaves external URLs with matching paths unchanged', () => {
+  const html = '<a href="https://cdn.example.net/about">External</a>';
+
+  assert.equal(
+    rewriteInternalLinks(html, 'https://example.com/', new Map([['/about', 'about.html']]), false),
+    html
+  );
+});
+
+test('rewriteInternalLinks skips canonical link elements', () => {
+  const html = '<link rel="canonical" href="/about"><a href="/about">About</a>';
+
+  assert.equal(
+    rewriteInternalLinks(html, 'https://example.com/', new Map([['/about', 'about.html']]), false),
+    '<link rel="canonical" href="/about"><a href="subpages/about.html">About</a>'
+  );
+});
+
+test('rewriteInternalLinks points subpage root links back to index', () => {
+  const html = '<a class="home" href = "/#hero">Home</a>';
+
+  assert.equal(
+    rewriteInternalLinks(html, 'https://example.com/', new Map(), true),
+    '<a class="home" href = "../index.html#hero">Home</a>'
+  );
+});
+
+test('Framer asset filters do not drop a site-owned init.mjs', () => {
+  const shouldSkip = (url: string) => framer.skipAssetUrls?.some((pattern) => pattern.test(url));
+
+  assert.equal(shouldSkip('https://app.framerstatic.com/runtime/init.mjs'), true);
+  assert.equal(shouldSkip('https://example.com/runtime/init.mjs'), false);
+});
+
+test('buildOutput runs index and subpages through the same HTML pipeline', async (t) => {
+  const outDir = await fs.mkdtemp(path.join(os.tmpdir(), 'framer-export-test-'));
+  t.after(() => fs.rm(outDir, { recursive: true, force: true }));
+  await fs.mkdir(path.join(outDir, 'subpages'));
+
+  const platform: PlatformHandler = {
+    name: 'unknown',
+    displayName: 'Test',
+    category: 'builder',
+    priority: 0,
+    detectByUrl: () => false,
+    detectByHtml: () => false,
+    stripDomains: [],
+    stripSelectors: [],
+    stripPatterns: [],
+    hydrationTimeout: 0,
+    needsHydrationCheck: false,
+    mapAssetDir: () => null,
+    rewriteUrlPatterns: [{ from: /OLD/g, to: 'NEW' }],
+    postCapture: (html) => html.replace('</body>', '<p>postCapture</p></body>'),
+  };
+  const exporter: ExporterContext = {
+    siteUrl: 'https://example.com/',
+    outDir,
+    assets: new AssetMap(),
+    browser: null,
+    page: null,
+    ssrHTML: '<html><head></head><body>OLD<a href="/about">About</a></body></html>',
+    platform,
+    subpages: new Map([['https://example.com/about', 'about.html']]),
+  };
+  await fs.writeFile(
+    path.join(outDir, 'subpages', 'about.html'),
+    '<html><head></head><body>OLD<a href="/">Home</a></body></html>'
+  );
+
+  await buildOutput(exporter);
+
+  const index = await fs.readFile(path.join(outDir, 'index.html'), 'utf8');
+  const subpage = await fs.readFile(path.join(outDir, 'subpages', 'about.html'), 'utf8');
+  assert.match(index, /NEW/);
+  assert.match(index, /postCapture/);
+  assert.match(index, /href="subpages\/about\.html"/);
+  assert.match(index, /rel="canonical" href="https:\/\/example\.com"/);
+  assert.match(subpage, /NEW/);
+  assert.match(subpage, /postCapture/);
+  assert.match(subpage, /href="\.\.\/index\.html"/);
+  assert.match(subpage, /rel="canonical" href="https:\/\/example\.com\/about"/);
+});


### PR DESCRIPTION
On Framer sites `--subpages` finds no sub-pages at all, and the pages it writes on other platforms only render while the source site is still online. This PR fixes both, plus two related problems that surfaced once sub-pages actually worked.

Framer drops its route anchors during hydration, so scanning the rendered DOM returns zero links. Link discovery now also reads `<a href>` out of the SSR HTML that the exporter has already fetched, which is where those routes survive.

Crawled pages were being written raw, with CDN URLs and the platform badge still in them. They now go through the same pipeline as `index.html`: badge and tracking stripped, asset URLs rewritten to `../assets/…`, and internal links pointed at the exported files in both directions, so `index.html` links to `subpages/works_lisiere.html` and the sub-page links back.

`AssetMap.rewrite()` emitted bare paths for assets sitting next to the importing file, which turned `import("https://…/init.mjs")` into `import("init.mjs")`. That fails to resolve as a bare module specifier, so those paths are now prefixed with `./`.

The Framer editor bar was never being stripped: the pattern matched `localStorage.get(` while Framer emits `getItem(`. It also builds its iframe URL from `import.meta.url`, so a mirrored copy points back at the export's own script directory and 404s in a loop. I added `skipAssetUrls` to the platform contract and used it to keep `init.mjs`, `editorbar.*.mjs` and `EditButton-*.mjs` out of the mirror entirely.

Finally, clean route paths in `serve.js` fell back to `index.html`, which then resolved its relative asset URLs against `/works/` and 404'd on everything. A request for `/works/lisiere` now serves `subpages/works_lisiere.html` when that file exists, and falls back to the SPA shell as before when it doesn't.

Two things this does not fix. Fonts declared in `@font-face` or preload links but never fetched by the browser still point at the CDN. And sub-page asset paths are relative one level up, so a route deeper than one segment resolves them against the wrong base when it is reached through the serve.js fallback.

Since opening this, I exported https://oberon.framer.website/ end to end and compared it against the live site. The mirror rendered, but the page scripts died on load and several assets were missing, so the following commits fix what that surfaced.

Stripping the badge left its bootstrap behind. `script_main` calls `hydrateRoot(document.getElementById("__framer-badge-container"), …)`, and once the export removes that container the call throws React error #405, which takes the rest of the page scripts down with it. The bootstrap is now removed from the mirrored JS along with the markup.

`AssetMap.rewrite()` replaced any occurrence of a mirrored URL, including where it was only the prefix of a deeper one. Framer requests `https://framer.com/edit` for the editor bar iframe, so mirroring that page turned `https://framer.com/edit/init.mjs` into `../../assets/misc/edit-0b7264/init.mjs` and 404'd. Replacement now skips a match followed by `/`, and `framer.com/edit` is added to `skipAssetUrls` so the editor page is never mirrored at all. The editor bar import is pointed at an inert data: module, so an export never reaches back out to framer.com.

`rewriteUrlPatterns` was documented as applying to HTML and downloaded text files, but only ever ran on HTML. It now runs on mirrored JS and CSS too, which is what the two rewrites above need, and it is renamed to `rewritePatterns` since it is no longer only about URLs.

Route and font chunks load lazily, so a single crawl never requests them and the mirror was left with fourteen dead `import("./chunk.mjs")` calls that broke navigation. After the download pass the exporter now follows sibling specifiers out of the JS already on disk and pulls in whatever is missing, repeating until the graph closes.

The crawler ran at a device pixel ratio of 1, so responsive images mirrored the 1x variant and backgrounds rendered visibly softer than the original. Capture is now at 2x.

Internal links lost their fragment when they were pointed at the exported files, so `./contacts#home` became `subpages/contacts.html` and landed at the top of the page instead of the section it names. The hash is now kept.

With these, the exported Oberon page reports no console errors and no failed requests, every route matches the live page height, and the only visual difference left is the removed Framer badge.

One thing this does not fix. Framer builds its CMS index URL at runtime from a hardcoded CDN base, so that single range request still goes to framerusercontent.com even though the `.framercms` file is mirrored. Collection content is server-rendered into the HTML, so pages render correctly without it.

## Summary by Sourcery

Make exported sub-pages and Framer mirrors self-contained, correctly linked, and resilient to platform-specific scripts and lazy assets.

New Features:
- Add sub-page crawling and local route generation for exported sites.
- Add configurable device-pixel-ratio capture through the CLI.
- Resolve lazily loaded JavaScript chunks during asset downloading.

Bug Fixes:
- Fix Framer sub-page discovery by scanning server-rendered HTML as well as the hydrated DOM.
- Process crawled pages through the same cleanup, asset-rewriting, and link-rewriting pipeline as the index page.
- Prevent mirrored Framer editor assets and badge bootstrap code from breaking exported pages or reaching back to the source site.
- Fix relative module imports, route serving, URL replacement boundaries, and fragment preservation in mirrored links.

Enhancements:
- Extend platform asset handling with skipped URLs, lazy chunk directories, and generalized rewrite patterns.
- Serve exported sub-pages for clean route paths while retaining SPA fallback behavior.
- Capture assets at higher pixel density when requested to improve responsive image fidelity.

Documentation:
- Document the sub-page and device-pixel-ratio command-line options.

Tests:
- Add unit coverage for URL replacement, internal-link rewriting, Framer asset filtering, and index/sub-page output processing.

Chores:
- Add a unit test command to the package scripts.
