### PR TITLE
Localise icons and social images that only appear in HTML, and build on npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test": "node --import tsx --test tests/unit/*.test.ts",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"src/**/*.ts\"",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "prepack": "npm run build"
   },

--- a/src/assets/html-refs.ts
+++ b/src/assets/html-refs.ts
@@ -1,0 +1,73 @@
+import { URL } from 'url';
+/**
+ * Resources that a page declares in its markup but that a browser never
+ * requests while rendering it: touch icons, theme-scoped favicons, web app
+ * manifests and social preview images.
+ *
+ * Asset discovery runs off the network log, so these are absent from the
+ * asset map and keep pointing at the origin in the exported copy.
+ */
+const LINK_RELS: Set<string> = new Set([
+  'icon',
+  'shortcut',
+  'apple-touch-icon',
+  'apple-touch-icon-precomposed',
+  'mask-icon',
+  'manifest',
+]);
+const META_KEYS: Set<string> = new Set([
+  'og:image',
+  'og:image:url',
+  'og:image:secure_url',
+  'twitter:image',
+  'twitter:image:src',
+]);
+const TAG_RE = /<(link|meta)\b[^>]*>/gi;
+function attr(tag: string, name: string): string | null {
+  const re = new RegExp(`\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s"'>]+))`, 'i');
+  const m = tag.match(re);
+  if (!m) return null;
+  return (m[2] ?? m[3] ?? m[4] ?? '').trim();
+}
+function decode(value: string): string {
+  return value.replace(/&amp;/g, '&');
+}
+/**
+ * Collect every absolute http(s) URL declared by the icon, manifest and social
+ * preview tags in `html`, resolved against `baseUrl`. Order is preserved and
+ * duplicates are dropped.
+ */
+export function collectHtmlResourceUrls(html: string, baseUrl: string): string[] {
+  const found: Set<string> = new Set();
+  const out: string[] = [];
+  for (const [tag, rawName] of html.matchAll(TAG_RE) as Iterable<RegExpMatchArray>) {
+    const name: string = rawName.toLowerCase();
+    let raw: string | null = null;
+    if (name === 'link') {
+      const rel: string | null = attr(tag, 'rel');
+      if (!rel) continue;
+      const tokens: string[] = rel.toLowerCase().split(/\s+/).filter(Boolean);
+      if (!tokens.some((t) => LINK_RELS.has(t))) continue;
+      raw = attr(tag, 'href');
+    } else {
+      const key: string | null = attr(tag, 'property') ?? attr(tag, 'name');
+      if (!key || !META_KEYS.has(key.toLowerCase())) continue;
+      raw = attr(tag, 'content');
+    }
+    if (!raw) continue;
+    const href: string = decode(raw);
+    if (!href || /^(data|blob|javascript|about):/i.test(href)) continue;
+    let resolved: URL;
+    try {
+      resolved = new URL(href, baseUrl);
+    } catch {
+      continue;
+    }
+    if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') continue;
+    const url: string = resolved.toString();
+    if (found.has(url)) continue;
+    found.add(url);
+    out.push(url);
+  }
+  return out;
+}

--- a/src/exporter/html-resources.ts
+++ b/src/exporter/html-resources.ts
@@ -1,0 +1,39 @@
+import { CFG } from '../config/index.js';
+import { log, success } from '../logger/index.js';
+import { collectHtmlResourceUrls } from '../assets/html-refs.js';
+import type { ExporterContext } from '../types.js';
+/**
+ * Queue the resources a page only declares in its markup.
+ *
+ * Assets are discovered from the network log, so anything the browser never
+ * fetches - touch icons, the dark-scheme favicon, the web app manifest, the
+ * Open Graph and Twitter preview images - is missing from the asset map and
+ * survives the rewrite as an absolute URL back to the origin. Registering them
+ * here, before the download phase, lets the existing pipeline fetch and rewrite
+ * them like any other asset.
+ */
+export function registerHtmlResources(exporter: ExporterContext): void {
+  const stripDomains: string[] = [...CFG.sharedStripDomains, ...exporter.platform.stripDomains];
+  const documents: string[] = [exporter.ssrHTML, ...exporter.subpages.values()];
+  let added = 0;
+  for (const html of documents) {
+    if (!html) continue;
+    for (const url of collectHtmlResourceUrls(html, exporter.siteUrl)) {
+      if (exporter.assets.entries.has(url)) continue;
+      let host: string;
+      try {
+        host = new URL(url).hostname;
+      } catch {
+        continue;
+      }
+      if (stripDomains.some((d) => host.includes(d))) continue;
+      if (exporter.platform.skipAssetUrls?.some((re) => re.test(url))) continue;
+      if (exporter.assets.localPathFor(url, exporter.platform)) added++;
+    }
+  }
+  if (added > 0) {
+    success('Queued ' + added + ' resource(s) declared in HTML but never requested');
+  } else {
+    log('No HTML-declared resources left to localise');
+  }
+}

--- a/src/exporter/index.ts
+++ b/src/exporter/index.ts
@@ -11,6 +11,7 @@ import { launchAndCapture, captureSubpage, closeBrowser } from './capture.js';
 import { extractInternalLinks, normalizeInternalLink, hostKey } from './links.js';
 import { AntiBotError } from './anti-bot.js';
 import { downloadAll, downloadLazyChunks } from './download.js';
+import { registerHtmlResources } from './html-resources.js';
 import { buildOutput } from './output.js';
 import { printSummary } from './summary.js';
 import { runAiPromptAssistant } from '../ai/prompt-assistant.js';
@@ -146,6 +147,7 @@ export class FramerExporter implements ExporterContext {
         await this.crawlSubpages();
       }
       await closeBrowser(this);
+      registerHtmlResources(this);
       this.phase('Downloading assets...');
       this.cooking.update('Downloading assets...');
       await downloadAll(this);

--- a/tests/unit/html-refs.test.ts
+++ b/tests/unit/html-refs.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { collectHtmlResourceUrls } from '../../src/assets/html-refs.js';
+const BASE = 'https://example.framer.app/';
+test('collects touch icons, scheme-scoped favicons and the manifest', () => {
+  const html = `
+    <link rel="icon" href="https://cdn.example.com/light.png" media="(prefers-color-scheme: light)">
+    <link href="https://cdn.example.com/dark.png" rel="icon" media="(prefers-color-scheme: dark)">
+    <link rel="apple-touch-icon" href="https://cdn.example.com/touch.png">
+    <link rel="apple-touch-icon-precomposed" href="/touch-pre.png">
+    <link rel="mask-icon" href="/mask.svg" color="#000">
+    <link rel="manifest" href="/site.webmanifest">
+  `;
+  assert.deepEqual(collectHtmlResourceUrls(html, BASE), [
+    'https://cdn.example.com/light.png',
+    'https://cdn.example.com/dark.png',
+    'https://cdn.example.com/touch.png',
+    'https://example.framer.app/touch-pre.png',
+    'https://example.framer.app/mask.svg',
+    'https://example.framer.app/site.webmanifest',
+  ]);
+});
+test('collects Open Graph and Twitter preview images', () => {
+  const html = `
+    <meta property="og:image" content="https://cdn.example.com/og.jpg">
+    <meta property="og:image:secure_url" content="https://cdn.example.com/og-secure.jpg">
+    <meta name="twitter:image" content="https://cdn.example.com/tw.jpg">
+  `;
+  assert.deepEqual(collectHtmlResourceUrls(html, BASE), [
+    'https://cdn.example.com/og.jpg',
+    'https://cdn.example.com/og-secure.jpg',
+    'https://cdn.example.com/tw.jpg',
+  ]);
+});
+test('ignores unrelated link rels and meta tags', () => {
+  const html = `
+    <link rel="stylesheet" href="https://cdn.example.com/app.css">
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link rel="canonical" href="https://example.framer.app/about">
+    <meta name="description" content="https://cdn.example.com/not-an-asset.png">
+    <meta property="og:title" content="Example">
+  `;
+  assert.deepEqual(collectHtmlResourceUrls(html, BASE), []);
+});
+test('skips data URIs and non-http schemes, and de-duplicates', () => {
+  const html = `
+    <link rel="icon" href="data:image/png;base64,AAAA">
+    <link rel="apple-touch-icon" href="ftp://example.com/icon.png">
+    <meta property="og:image" content="https://cdn.example.com/same.jpg">
+    <meta name="twitter:image" content="https://cdn.example.com/same.jpg">
+  `;
+  assert.deepEqual(collectHtmlResourceUrls(html, BASE), ['https://cdn.example.com/same.jpg']);
+});
+test('handles single quotes, unquoted values and HTML-escaped ampersands', () => {
+  const html = `
+    <link rel='apple-touch-icon' href='https://cdn.example.com/a.png'>
+    <link rel=icon href=https://cdn.example.com/b.png>
+    <meta property="og:image" content="https://cdn.example.com/c.jpg?w=1&amp;h=2">
+  `;
+  assert.deepEqual(collectHtmlResourceUrls(html, BASE), [
+    'https://cdn.example.com/a.png',
+    'https://cdn.example.com/b.png',
+    'https://cdn.example.com/c.jpg?w=1&h=2',
+  ]);
+});
+test('matches rel token lists case-insensitively', () => {
+  const html = `<link REL="SHORTCUT ICON" HREF="https://cdn.example.com/fav.ico">`;
+  assert.deepEqual(collectHtmlResourceUrls(html, BASE), ['https://cdn.example.com/fav.ico']);
+});


### PR DESCRIPTION
Two independent fixes found while mirroring a Framer site. Each is a separate commit; happy to split them into two PRs if you prefer.

## 1. Icons, manifest and social images declared only in HTML are never localised

Asset discovery runs off the Puppeteer network log (`page.on('response')` in `src/exporter/capture.ts`), so a resource is mirrored only if the browser actually requests it while rendering. Several standard head tags are never requested:

| Tag | Why the browser never fetches it |
|---|---|
| `<link rel="apple-touch-icon">` | desktop Chrome does not request touch icons |
| `<link rel="icon" media="(prefers-color-scheme: dark)">` | only the matching scheme is fetched |
| `<link rel="manifest">` | not fetched in a plain headless load |
| `<meta property="og:image">` | never fetched by a browser at all |
| `<meta name="twitter:image">` | same |

They never enter the asset map, so the download phase skips them and `AssetMap.rewrite` leaves them alone. The exported copy keeps absolute URLs back to the origin.

Exporting a real Framer site left five of these pointing at `framerusercontent.com`:

```html
<link href="https://framerusercontent.com/images/6Ea…png" rel="icon" media="(prefers-color-scheme: dark)">
<link rel="apple-touch-icon" href="https://framerusercontent.com/images/R9l…png">
<meta property="og:image" content="https://framerusercontent.com/assets/cQB…jpg">
<meta name="twitter:image" content="https://framerusercontent.com/assets/cQB…jpg">
```

The *light* favicon on the same page was localised correctly, because Chrome happened to request that one — which is a good illustration of the underlying cause.

This undercuts what the mirror is for: the copy is not self-contained, it phones home for those files, and they break the moment the source site goes away — often the exact reason someone exported it.

**Fix.** `src/assets/html-refs.ts` collects these references from the captured HTML, and `src/exporter/html-resources.ts` registers them in the asset map after the crawl and before the download phase, so the existing pipeline downloads and rewrites them like any other asset. Tracking domains and the platform's `skipAssetUrls` are still honoured; `data:`/`blob:` and non-HTTP values are ignored; relative hrefs resolve against the site URL.

After the change, same site:

```html
<link href="assets/images/BFHjkEgxf9FJfogw3MrZtvBOk.png" rel="icon" media="(prefers-color-scheme: light)">
<link href="assets/images/6Ea5W977ebTnO00YtbUVhmJrRE.png" rel="icon" media="(prefers-color-scheme: dark)">
<link rel="apple-touch-icon" href="assets/images/R9lpBU38PawHI1SdFLKf9lK1oI.png">
<meta property="og:image" content="assets/misc/cQBw8mFlIUXS8XGFYr1xdVsJZWs.jpg">
<meta name="twitter:image" content="assets/misc/cQBw8mFlIUXS8XGFYr1xdVsJZWs.jpg">
```

All five files present on disk, no remote URLs left in those tags. The run logs `Queued 3 resource(s) declared in HTML but never requested`.

## 2. A fresh clone is not runnable after `npm install`

The README documents installing from source:

```bash
git clone https://github.com/danbenba/FramerExport.git
cd FramerExport
npm install
```

`dist/` is gitignored and only built by `prepack` / `prepublishOnly`, which are publish-time paths, so `npm install` leaves no `dist/`. All three bin entry points import `../dist/cli/index.js`, so each fails immediately:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '…/FramerExport/dist/cli/index.js'
```

**Fix.** Add `"prepare": "npm run build"`. npm runs `prepare` after install in the package root and when installing from a git URL, and skips it for published registry tarballs, which already ship `dist/` via `files`. So this only affects the source path, which is the one that is currently broken.

## Verification

- Clean clone of `master`, `npm install` → no `dist/`, CLI throws. With the `prepare` script → `npm install` builds and `framer-export --version` prints.
- `npm test` — 175 passing (169 existing, 6 new in `tests/unit/html-refs.test.ts` covering rel token lists, quoting styles, `&amp;` in URLs, relative hrefs, de-duplication, and non-HTTP schemes).
- `npm run typecheck` clean.
- End-to-end export of a live Framer site before and after, diffed as shown above.

No dependencies added; the collector is regex-based, matching the existing string-processing style in `src/exporter/output.ts`.

## Summary by Sourcery

Make exported sites self-contained by localising browser-unrequested HTML assets and ensure fresh source installs build the CLI automatically.

New Features:
- Localise icons, manifests, and Open Graph/Twitter images declared in HTML even when browsers do not request them during rendering.

Bug Fixes:
- Prevent exported pages from retaining remote URLs for HTML-declared assets.
- Make source checkouts runnable by building the distribution during npm install.

Enhancements:
- Resolve relative HTML asset references, de-duplicate resources, and preserve existing domain and platform filtering rules.

Build:
- Add the npm prepare lifecycle script to build the project after installation from source or a Git URL.

Tests:
- Add unit coverage for HTML resource collection and registration across root documents and subpages.